### PR TITLE
Upgrade to Python@3.10 and pydicom@3.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ repository = "https://github.com/sjoerdk/dicomgenerator"
 include = ["dicomgenerator/resources"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
-pydicom = "^2.3.0"
+python = ">=3.10,<3.11"
+pydicom = "3.0.1"
 numpy = "^1.23.4"
 factory-boy = "^3.2.1"
 click = "^8.1.3"


### PR DESCRIPTION
Hi @sjoerdk 

**Summary:**  
This PR upgrades the Python version to `>=3.10,<3.11` and updates the `pydicom` dependency to `3.0.1` to resolve a bug causing DICOM images to appear inverted.  

**Changes Made:**  
- Updated Python version requirement from `^3.8` to `>=3.10,<3.11`.  
- Upgraded `pydicom` from `^2.3.0` to `3.0.1`.  

**Reason for Update:**  
The upgrade addresses a specific issue where DICOM images appeared inverted due to:  
1. Incorrect handling of `Bits Stored` during conversion of Float and Double Float Pixel Data.  
2. Errors in decoding pixel data with `Bits Allocated = 1` when frame boundaries were misaligned.  

**Testing:**  
-  **Results:** 18/18 tests passed with 5 warnings.  

![Screenshot 2024-12-26 at 18 16 08](https://github.com/user-attachments/assets/b9d3d514-926c-4db8-b1e7-e120a24a5870)



